### PR TITLE
Fix bugs in the machine list

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2247,9 +2247,9 @@ void MainFrame::select_tab(size_t tab/* = size_t(-1)*/)
                         m_printer_view->AddButton(
                             printer_name, host, (data->model_id), (data->fullname),
                             [host, this](wxMouseEvent &event) {
-                                wxString formattedHost = wxString::Format("http://%s", host);
-                                if (!host.Lower().starts_with("http"))
-                                    wxString formattedHost = wxString::Format("http://%s", host);
+                                wxString formattedHost = host;
+                                if (!formattedHost.Lower().starts_with("http"))
+                                    formattedHost = wxString::Format("http://%s", formattedHost);
                                 if (!formattedHost.Lower().ends_with("10088"))
                                     formattedHost = wxString::Format("%s:10088", formattedHost);
                                 this->m_printer_view->load_url(formattedHost);

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2236,26 +2236,22 @@ void MainFrame::select_tab(size_t tab/* = size_t(-1)*/)
                 if (printer != nullptr) {
                     wxString host = (printer->config.opt_string("print_host"));
 
-                    std::regex          ipRegex(R"(\b(?:\d{1,3}\.){3}\d{1,3}\b)");
-                    bool                isValidIPAddress = std::regex_match(host.ToStdString(), ipRegex);
-                    DynamicPrintConfig *cfg_t            = &(printer->config);
+                    DynamicPrintConfig *cfg_t = &(printer->config);
 
                     wxStringTokenizer tokenizer3((data->lower_name), wxT("*"), wxTOKEN_RET_EMPTY_ALL);
                     wxString          printer_name = tokenizer3.GetNextToken();
 
-                    if (isValidIPAddress) {
-                        m_printer_view->AddButton(
-                            printer_name, host, (data->model_id), (data->fullname),
-                            [host, this](wxMouseEvent &event) {
-                                wxString formattedHost = host;
-                                if (!formattedHost.Lower().starts_with("http"))
-                                    formattedHost = wxString::Format("http://%s", formattedHost);
-                                if (!formattedHost.Lower().ends_with("10088"))
-                                    formattedHost = wxString::Format("%s:10088", formattedHost);
-                                this->m_printer_view->load_url(formattedHost);
-                            },
-                            (data->selected), cfg_t);
-                    }
+                    m_printer_view->AddButton(
+                        printer_name, host, (data->model_id), (data->fullname),
+                        [host, this](wxMouseEvent &event) {
+                            wxString formattedHost = host;
+                            if (!formattedHost.Lower().starts_with("http"))
+                                formattedHost = wxString::Format("http://%s", formattedHost);
+                            if (!formattedHost.Lower().ends_with("10088"))
+                                formattedHost = wxString::Format("%s:10088", formattedHost);
+                            this->m_printer_view->load_url(formattedHost);
+                        },
+                        (data->selected), cfg_t);
                 }
             }
 
@@ -2268,9 +2264,7 @@ void MainFrame::select_tab(size_t tab/* = size_t(-1)*/)
                 const PhysicalPrinter &pp            = preset_bundle.physical_printers.get_selected_printer();
                 wxString               host          = pp.config.opt_string("print_host");
                 //B45
-                std::regex ipRegex(R"(\b(?:\d{1,3}\.){3}\d{1,3}\b)");
-                bool       isValidIPAddress = std::regex_match(host.ToStdString(), ipRegex);
-                if (host.empty() || !isValidIPAddress) {
+                if (host.empty()) {
                     tem_host = "";
                     host     = wxString::Format("file://%s/web/qidi/missing_connection.html", from_u8(resources_dir()));
                 }

--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -446,9 +446,9 @@ void PrinterWebView::OnAddButtonClick(wxCommandEvent &event)
         std::string   printer_name  = printer.name;
         wxString      host          = printer.config.opt_string("print_host");
 
-        wxString formattedHost = wxString::Format("http://%s", host);
-        if (!host.Lower().starts_with("http"))
-            wxString formattedHost = wxString::Format("http://%s", host);
+        wxString formattedHost = host;
+        if (!formattedHost.Lower().starts_with("http"))
+            formattedHost = wxString::Format("http://%s", formattedHost);
         if (!formattedHost.Lower().ends_with("10088"))
             formattedHost = wxString::Format("%s:10088", formattedHost);
 

--- a/src/slic3r/GUI/PrinterWebView.hpp
+++ b/src/slic3r/GUI/PrinterWebView.hpp
@@ -70,7 +70,7 @@ public:
 
 
     wxString getLabel() { return full_label; }
-    wxString getIPLabel() { return m_ip_text; }
+    wxString getHostLabel() { return m_host_text; }
 
 
     void SetBitMap(const wxBitmap &bitmap)
@@ -92,9 +92,9 @@ public:
     }
 
 
-    void SetIPText(const wxString &text)
+    void SetHostText(const wxString &text)
     {
-        m_ip_text = text;
+        m_host_text = text;
         Refresh();
     }
     void SetStateText(const wxString &text)
@@ -149,10 +149,10 @@ public:
     void OnMouseLeftUp(wxMouseEvent &event);
     void OnClickHandler(wxCommandEvent &event);
     void SetStatusThread(std::thread thread) { m_statusThread = std::move(thread); }
-    std::thread CreatThread(const wxString &buttonText, const wxString &ip, DynamicPrintConfig *cfg_t)
+    std::thread CreatThread(const wxString &buttonText, const wxString &host, DynamicPrintConfig *cfg_t)
     {
 
-        std::thread thread([this, buttonText,ip, cfg_t]() {
+        std::thread thread([this, buttonText, host, cfg_t]() {
              std::unique_ptr<PrintHost> printhost(PrintHost::get_print_host(cfg_t));
              if (!printhost) {
                  BOOST_LOG_TRIVIAL(error) << ("Could not get a valid Printer Host reference");
@@ -205,7 +205,7 @@ private:
     bool     m_isHovered; 
     wxString full_label;
     wxString m_name_text; 
-    wxString m_ip_text; 
+    wxString m_host_text; 
     wxString m_state_text; 
     wxString m_progress_text; 
     std::function<void(wxMouseEvent &)> m_handlerl;
@@ -246,7 +246,7 @@ public:
     //void SendRecentList(int images);
     void SetButtons(std::vector<MachineListButton *> buttons);
     void  AddButton(const wxString &                           device_name,
-                    const wxString &                           ip,
+                    const wxString &                           host,
                     const wxString &                           machine_type,
                     const wxString &                           fullname,
                     const std::function<void(wxMouseEvent &)> &handler,


### PR DESCRIPTION
These commits fix 2 bugs I found in the machine list.

One regarding the formatting of the address of printers. The current code hardcodes the "http://" prefix to the address specified by the user, so if he writes, for example, "http://1.2.3.4", it becomes "http://http://1.2.3.4", and this is an invalid address.

The second is a UI bug regarding the display of printers with a hostname (instead of an IP address) in the machine list. When adding a printer by hostname, it doesn't appear on the list (this is a UI bug, becuase the printer is saved corectly to the config file and the page loads succesfully, but it just doesn't appear on the list). Actually it's not really a bug, but an incorrect assumption by the developer, because in the code, there is a check that validates the printer's host is only an IP address, but as you can see it can also be a hostname, so this check is redundant. I removed the check and now printers with an hostname should be displayed correctly.


Disclaimer: I couldn't build the program so I actually never tried the fixes. Please check them before deciding to merge.