### PR TITLE
BedShapePanel::update_exclude_area() returns a reference to a std::vector<Vec2d> that has already been destroyed

### DIFF
--- a/src/slic3r/GUI/BedShapeDialog.cpp
+++ b/src/slic3r/GUI/BedShapeDialog.cpp
@@ -601,7 +601,7 @@ void BedShapePanel::update_shape()
 }
 
 //Y20
-const std::vector<Vec2d>&  BedShapePanel::update_exclude_area(ConfigOptionsGroupShp options_group)
+const std::vector<Vec2d>  BedShapePanel::update_exclude_area(ConfigOptionsGroupShp options_group)
 {
     Vec2d exclude_max(Vec2d::Zero());
     Vec2d exclude_min(Vec2d::Zero());

--- a/src/slic3r/GUI/BedShapeDialog.hpp
+++ b/src/slic3r/GUI/BedShapeDialog.hpp
@@ -95,7 +95,7 @@ private:
     void		set_exclude_area(const ConfigOptionPoints& points_0, const ConfigOptionPoints& points_1);
     void		update_preview();
 	void		update_shape();
-    const std::vector<Vec2d>&		update_exclude_area(ConfigOptionsGroupShp options_group);
+    const std::vector<Vec2d>		update_exclude_area(ConfigOptionsGroupShp options_group);
 	void		load_stl();
     void		load_texture();
     void		load_model();


### PR DESCRIPTION
- Fixed return of bad reference to local variable from BedShapePanel::update_exclude_area()

This issue was causing a segmentation fault when trying to start the configuration wizard on the very first run of QIDISlicer on my new Linux install